### PR TITLE
PIM-3925 : do not display menu if no child displayable

### DIFF
--- a/src/Oro/Bundle/NavigationBundle/Menu/ConfigurationBuilder.php
+++ b/src/Oro/Bundle/NavigationBundle/Menu/ConfigurationBuilder.php
@@ -96,6 +96,21 @@ class ConfigurationBuilder implements BuilderInterface
             }
         }
         $menu->setExtra('isAllowed', $isAllowed);
+
+        if ($menu->hasChildren()) {
+            $willDisplaySomeChildren = false;
+
+            foreach ($menu->getChildren() as $child) {
+                if ($child->isDisplayed() && $child->getExtra('isAllowed')) {
+                    $willDisplaySomeChildren = true;
+                    break;
+                }
+            }
+
+            if (!$willDisplaySomeChildren) {
+                $menu->setDisplay(false);
+            }
+        }
     }
 
     /**

--- a/src/Oro/Bundle/NavigationBundle/Menu/ConfigurationBuilder.php
+++ b/src/Oro/Bundle/NavigationBundle/Menu/ConfigurationBuilder.php
@@ -97,7 +97,7 @@ class ConfigurationBuilder implements BuilderInterface
         }
         $menu->setExtra('isAllowed', $isAllowed);
 
-        if ($menu->hasChildren()) {
+        if (!$menu->getExtra('showIfEmpty') && $menu->hasChildren()) {
             $willDisplaySomeChildren = false;
 
             foreach ($menu->getChildren() as $child) {


### PR DESCRIPTION
If all menu's children are not displayable and the extra option "hideIfEmpty" is set to true, then the menu will not be shown

| Q | A |
| --- | --- |
| Bug fix? | y |
| New feature? | n |
| BC breaks? | n |
| CI currently passes? | y |
| Tests pass? |  |
| Scenarios pass? |  |
| Checkstyle issues?* |  |
| PMD issues?** |  |
| Changelog updated? | n |
| Fixed tickets | PIM-3925 |
| DB schema updated? |  |
| Migration script? |  |
| Doc PR |  |
