### PR TITLE
[TR] PIM-5150: Grid is very slow to load with a lot of attributes

### DIFF
--- a/src/Oro/Bundle/FilterBundle/Filter/AbstractFilter.php
+++ b/src/Oro/Bundle/FilterBundle/Filter/AbstractFilter.php
@@ -2,7 +2,9 @@
 
 namespace Oro\Bundle\FilterBundle\Filter;
 
+use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
 
@@ -22,6 +24,9 @@ abstract class AbstractFilter implements FilterInterface
 
     /** @var Form */
     protected $form;
+
+    /** @var FormBuilderInterface */
+    protected $formBuilder;
 
     /**
      * Constructor
@@ -61,6 +66,22 @@ abstract class AbstractFilter implements FilterInterface
     }
 
     /**
+     * @return FormBuilderInterface
+     */
+    protected function getFormBuilder()
+    {
+        if (!$this->formBuilder) {
+            $this->formBuilder = $this->formFactory->createBuilder(
+                $this->getFormType(),
+                [],
+                array_merge($this->getOr(FilterUtility::FORM_OPTIONS_KEY, []), ['csrf_protection' => false])
+            );
+        }
+
+        return $this->formBuilder;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getName()
@@ -73,14 +94,19 @@ abstract class AbstractFilter implements FilterInterface
      */
     public function getMetadata()
     {
-        $formView = $this->getForm()->createView();
-        $typeView = $formView->children['type'];
+        $formBuilderType = $this->getFormBuilder()->get('type');
+        $operatorChoices = $formBuilderType->getOption('choices');
+
+        $choices = [];
+        foreach ($operatorChoices as $key => $choice) {
+            $choices[] = new ChoiceView($key, (string) $key, $choice);
+        }
 
         $defaultMetadata = [
             'name'                     => $this->getName(),
             // use filter name if label not set
             'label'                    => ucfirst($this->name),
-            'choices'                  => $typeView->vars['choices'],
+            'choices'                  => $choices,
             FilterUtility::ENABLED_KEY => true,
         ];
 

--- a/src/Oro/Bundle/FilterBundle/Filter/NumberFilter.php
+++ b/src/Oro/Bundle/FilterBundle/Filter/NumberFilter.php
@@ -63,13 +63,13 @@ class NumberFilter extends AbstractFilter
      */
     public function getOperator($type)
     {
-        $operatorTypes = array(
+        $operatorTypes = [
             NumberFilterType::TYPE_EQUAL         => '=',
             NumberFilterType::TYPE_GREATER_EQUAL => '>=',
             NumberFilterType::TYPE_GREATER_THAN  => '>',
             NumberFilterType::TYPE_LESS_EQUAL    => '<=',
             NumberFilterType::TYPE_LESS_THAN     => '<',
-        );
+        ];
 
         return isset($operatorTypes[$type]) ? $operatorTypes[$type] : '=';
     }
@@ -81,9 +81,47 @@ class NumberFilter extends AbstractFilter
     {
         $metadata = parent::getMetadata();
 
-        $formView = $this->getForm()->createView();
-        $metadata['formatterOptions'] = $formView->vars['formatter_options'];
+        $formBuilder = $this->getFormBuilder();
+        $dataType = $formBuilder->getOption('data_type');
+        $metadata['formatterOptions'] = $this->getFormatterOptions($dataType);
 
         return $metadata;
+    }
+
+    /**
+     * This method has been copy/pasted from
+     * Oro\Bundle\FilterBundle\Form\Type\Filter\NumberFilterType
+     * because it was only available in the buildView() method.
+     *
+     * Since we don't build the view anymore for the metadata, we need this logic here.
+     *
+     * @param string $dataType
+     *
+     * @return array
+     */
+    protected function getFormatterOptions($dataType)
+    {
+        $formatterOptions = [];
+
+        switch ($dataType) {
+            case NumberFilterType::DATA_DECIMAL:
+                $formatterOptions['decimals'] = 2;
+                $formatterOptions['grouping'] = true;
+                break;
+            case NumberFilterType::DATA_INTEGER:
+            default:
+                $formatterOptions['decimals'] = 0;
+                $formatterOptions['grouping'] = false;
+        }
+
+        $formatter = new \NumberFormatter(\Locale::getDefault(), \NumberFormatter::DECIMAL);
+
+        $formatterOptions['orderSeparator'] = $formatterOptions['grouping']
+            ? $formatter->getSymbol(\NumberFormatter::GROUPING_SEPARATOR_SYMBOL)
+            : '';
+
+        $formatterOptions['decimalSeparator'] = $formatter->getSymbol(\NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
+
+        return $formatterOptions;
     }
 }

--- a/src/Oro/Bundle/FilterBundle/Grid/Extension/Configuration.php
+++ b/src/Oro/Bundle/FilterBundle/Grid/Extension/Configuration.php
@@ -9,6 +9,7 @@ use Oro\Bundle\FilterBundle\Filter\FilterUtility;
 
 class Configuration implements ConfigurationInterface
 {
+    const FILTERS_KEY          = 'filters';
     const FILTERS_PATH         = '[filters]';
     const COLUMNS_PATH         = '[filters][columns]';
     const DEFAULT_FILTERS_PATH = '[filters][default]';


### PR DESCRIPTION
This is the main part of improvement for product gird loading performance.

When the product grid is loaded, a `Form` is built for each attribute usable as grid filter so we can use the `FilterTypes` config to display filters. But it is very time consuming when using a lot of attributes in the grid.

This code avoids to build a `Form` for each attribute but instead call the `FormBuilder` which **already has the config** to display filters.
